### PR TITLE
Registry: remove detailedBalanceOfAt() as only active balance is checkpointed

### DIFF
--- a/docs/6-external-interface/4-guardians-registry.md
+++ b/docs/6-external-interface/4-guardians-registry.md
@@ -173,7 +173,7 @@ The following functions are state getters provided by the `GuardiansRegistry`:
     - **Locked:** Amount of active tokens that are locked due to ongoing disputes
     - **Pending deactivation:** Amount of active tokens that were requested for deactivation
 
-#### 6.4.2.8. Active balance of at
+#### 6.4.2.7. Active balance of at
 - **Inputs:**
     - **Guardian:** Address of the guardian querying the active balance of
     - **Term ID:** Identification number of the term to query on
@@ -181,14 +181,14 @@ The following functions are state getters provided by the `GuardiansRegistry`:
 - **Outputs:**
     - **Amount:** Amount of active tokens for guardian
 
-#### 6.4.2.9. Unlocked active balance of
+#### 6.4.2.8. Unlocked active balance of
 - **Inputs:**
     - **Guardian:** Address of the guardian querying the unlocked active balance of
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Amount:** Amount of active tokens of a guardian that are not locked due to ongoing disputes
 
-#### 6.4.2.10. Deactivation request
+#### 6.4.2.9. Deactivation request
 - **Inputs:**
     - **Guardian:** Address of the guardian querying the deactivation request of
 - **Pre-flight checks:** None
@@ -196,7 +196,7 @@ The following functions are state getters provided by the `GuardiansRegistry`:
     - **Amount:** Amount of tokens to be deactivated
     - **Available term ID:** Term in which the deactivated amount will be available
 
-#### 6.4.2.11. Activation lock
+#### 6.4.2.10. Activation lock
 - **Inputs:**
     - **Guardian:** Address of the guardian querying the activation lock of
     - **Lock manager:** Address of the lock manager querying the activation lock of
@@ -205,34 +205,34 @@ The following functions are state getters provided by the `GuardiansRegistry`:
     - **Amount:** Lock activation amount controlled by the given lock manager
     - **Total:** Total activation lock for the given guardian
 
-#### 6.4.2.12. Withdrawals lock term ID
+#### 6.4.2.11. Withdrawals lock term ID
 - **Inputs:**
     - **Guardian:** Address of the guardian querying the lock term ID of
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Term ID:** Term ID in which the guardian's withdrawals will be unlocked (due to final rounds)
 
-#### 6.4.2.13. Is activator whitelisted
+#### 6.4.2.12. Is activator whitelisted
 - **Inputs:**
     - **Activator:** Address of the activator being queried
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Allowed:** Whether the activator is whitelisted
 
-#### 6.4.2.14. Is lock manager whitelisted
+#### 6.4.2.13. Is lock manager whitelisted
 - **Inputs:**
     - **Lock manager:** Address of the lock manager being queried
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Allowed:** Whether the lock manager is whitelisted
 
-#### 6.4.2.15. Total active balance limit
+#### 6.4.2.14. Total active balance limit
 - **Inputs:** None
 - **Pre-flight checks:** None
 - **Outputs:**
     - **Total active balance limit:** Maximum amount of total active balance that can be held in the registry
 
-#### 6.4.2.16. Guardian ID
+#### 6.4.2.15. Guardian ID
 - **Inputs:**
     - **Guardian:** Address of the guardian querying the ID of
 - **Pre-flight checks:** None

--- a/docs/6-external-interface/4-guardians-registry.md
+++ b/docs/6-external-interface/4-guardians-registry.md
@@ -173,17 +173,6 @@ The following functions are state getters provided by the `GuardiansRegistry`:
     - **Locked:** Amount of active tokens that are locked due to ongoing disputes
     - **Pending deactivation:** Amount of active tokens that were requested for deactivation
 
-#### 6.4.2.7. Detailed balance of at
-- **Inputs:**
-    - **Guardian:** Address of the guardian querying the detailed balance information of
-    - **Term ID:** Identification number of the term to query on
-- **Pre-flight checks:** None
-- **Outputs:**
-    - **Active:** Amount of active tokens of a guardian
-    - **Available:** Amount of available tokens of a guardian
-    - **Locked:** Amount of active tokens that are locked due to ongoing disputes
-    - **Pending deactivation:** Amount of active tokens that were requested for deactivation
-
 #### 6.4.2.8. Active balance of at
 - **Inputs:**
     - **Guardian:** Address of the guardian querying the active balance of

--- a/packages/evm/contracts/registry/GuardiansRegistry.sol
+++ b/packages/evm/contracts/registry/GuardiansRegistry.sol
@@ -530,24 +530,6 @@ contract GuardiansRegistry is IGuardiansRegistry, ControlledRecoverable, Control
     }
 
     /**
-    * @dev Tell the detailed balance information of a guardian, fecthing for a given term id
-    * @param _guardian Address of the guardian querying the detailed balance information of
-    * @param _termId Term ID to query on
-    * @return active Amount of active tokens of a guardian
-    * @return available Amount of available tokens of a guardian
-    * @return locked Amount of active tokens that are locked due to ongoing disputes
-    * @return pendingDeactivation Amount of active tokens that were requested for deactivation
-    */
-    function detailedBalanceOfAt(address _guardian, uint64 _termId) external view
-        returns (uint256 active, uint256 available, uint256 locked, uint256 pendingDeactivation)
-    {
-        Guardian storage guardian = guardiansByAddress[_guardian];
-
-        active = _existsGuardian(guardian) ? tree.getItemAt(guardian.id, _termId) : 0;
-        (available, locked, pendingDeactivation) = _getBalances(guardian);
-    }
-
-    /**
     * @dev Tell the active balance of a guardian for a given term id
     * @param _guardian Address of the guardian querying the active balance of
     * @param _termId Term ID to query on

--- a/packages/evm/test/registry/guardians-registry-drafting.js
+++ b/packages/evm/test/registry/guardians-registry-drafting.js
@@ -83,8 +83,7 @@ contract('GuardiansRegistry', ([_, guardian500, guardian1000, guardian1500, guar
     }) => {
       for (const guardian of guardians) {
         guardian.unlockedActiveBalance = await registry.unlockedActiveBalanceOf(guardian.address)
-        const { active } = await registry.detailedBalanceOfAt(guardian.address, TERM_ID)
-        guardian.activeBalance = active
+        guardian.activeBalance = await registry.activeBalanceOfAt(guardian.address, TERM_ID)
       }
 
       const activeGuardians = guardians.filter(guardian => guardian.activeBalance.gte(MIN_ACTIVE_AMOUNT))
@@ -131,7 +130,7 @@ contract('GuardiansRegistry', ([_, guardian500, guardian1000, guardian1500, guar
     const lockFirstExpectedGuardian = async ({ disputeId, batchRequestedGuardians, roundRequestedGuardians, leftUnlockedAmount = bn(0) }) => {
       const guardian = await getFirstExpectedGuardianAddress({ disputeId, batchRequestedGuardians, roundRequestedGuardians })
       await registry.mockLock(guardian, leftUnlockedAmount)
-      const { active, locked } = await registry.detailedBalanceOfAt(guardian, TERM_ID)
+      const { active, locked } = await registry.detailedBalanceOf(guardian)
       assertBn(locked, active.sub(leftUnlockedAmount), 'guardian locked balance does not match')
     }
 


### PR DESCRIPTION
As discussed in #37, only the active balance is checkpointed so all the other balances should be obtained from `detailedBalanceOf()` instead.